### PR TITLE
Separate github repo info from contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ plugins: [
 GraphQL
 ```
 {
-  allGithubContributors {
+  allGithub {
     nodes {
       repository
       branch

--- a/README.md
+++ b/README.md
@@ -55,13 +55,19 @@ GraphQL
 {
   allGithubContributors {
     nodes {
+      repository
+      branch
+      root
+    }
+  }    
+  allGithubContributors {
+    nodes {
       contributors {
         date
         login
         name
       }
-      path,
-      href
+      path
     }
   }        
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -29,13 +29,25 @@ exports.sourceNodes = async ({ actions, createNodeId, createContentDigest }, opt
     }
   })
 
+  const repository = `${owner}/${name}`
+
+  actions.createNode({
+    repository,
+    branch,
+    root,
+    id: createNodeId(repository),
+    internal: {
+      type: 'Github',
+      contentDigest: createContentDigest(repository)
+    }
+  })
+
   for (const _path of paths) {
     const githubPath = path.join(root, _path.replace(process.cwd(), ''))
     const contributors = await githubFetchContributorsForPage(owner, name, branch, githubPath, token)
     actions.createNode({
       contributors,
       path: _path,
-      href: `https://github.com/${owner}/${name}`,
       id: createNodeId(_path),
       internal: {
         type: 'GithubContributors',

--- a/test/gatsby-node.test.js
+++ b/test/gatsby-node.test.js
@@ -67,21 +67,20 @@ test('sourceNodes', async () => {
     .mockResolvedValueOnce(contributors[1])
 
   await expect(gatsbyNode.sourceNodes(gatsbyHelpers, options)).resolves.toEqual(undefined)
-  expect(gatsbyHelpers.actions.createNode).toHaveBeenCalledTimes(pages.length)
+  expect(gatsbyHelpers.actions.createNode).toHaveBeenCalledTimes(pages.length + 1)
   expect(mockGithubFetchContributors).toHaveBeenCalledTimes(pages.length)
 
   options.root = 'my-root' // coverage
   mockGlobby.mockResolvedValueOnce([])
   await expect(gatsbyNode.sourceNodes(gatsbyHelpers, options)).resolves.toEqual(undefined)
-  expect(gatsbyHelpers.actions.createNode).toHaveBeenCalledTimes(pages.length)
+  expect(gatsbyHelpers.actions.createNode).toHaveBeenCalledTimes(pages.length + 2)
   expect(mockGithubFetchContributors).toHaveBeenCalledTimes(pages.length)
 
   pages.forEach((page, index) => {
     const { owner, name, branch, token } = options.repo
     expect(mockGithubFetchContributors).toHaveBeenNthCalledWith(index + 1, owner, name, branch, page, token)
-    expect(gatsbyHelpers.actions.createNode).toHaveBeenNthCalledWith(index + 1, expect.objectContaining({
+    expect(gatsbyHelpers.actions.createNode).toHaveBeenNthCalledWith(index + 2, expect.objectContaining({
       contributors: contributors[index],
-      href: `https://github.com/${owner}/${name}`,
       internal: expect.objectContaining({
         type: 'GithubContributors'
       })


### PR DESCRIPTION
To avoid having duplicated info in contributor nodes. Also adds root and branch info.